### PR TITLE
Lock bluepy version

### DIFF
--- a/custom_components/tion/manifest.json
+++ b/custom_components/tion/manifest.json
@@ -6,7 +6,7 @@
     "fan"
   ],
   "requirements": [
-    "bluepy",
+    "bluepy==1.3.0",
     "git+https://github.com/TionAPI/tion_python.git@lite#tion==1.0.0"
   ],
   "codeowners": [


### PR DESCRIPTION
Use 1.3.0, like [all other projects](https://github.com/home-assistant/core/search?l=JSON&q=bluepy) in Home Assistant.