### PR TITLE
Use tion python module from PyPi

### DIFF
--- a/custom_components/tion/climate.py
+++ b/custom_components/tion/climate.py
@@ -5,7 +5,7 @@ import time
 import datetime
 from bluepy import btle
 from typing import Tuple, Callable
-from tion import s3 as tion
+from tion_btle import s3 as tion
 from homeassistant.helpers.entity import Entity
 from homeassistant.config_entries import ConfigEntry
 

--- a/custom_components/tion/config_flow.py
+++ b/custom_components/tion/config_flow.py
@@ -89,7 +89,7 @@ class TionFlow:
 
     async def async_step_pair(self, input):
         """Pair host and breezer"""
-        from tion import s3 as tion
+        from tion_btle import s3 as tion
         _tion = tion(mac)
         _tion.pair()
         return self.async_create_entry(title=self._data['name'], data=self._data)

--- a/custom_components/tion/manifest.json
+++ b/custom_components/tion/manifest.json
@@ -7,7 +7,7 @@
   ],
   "requirements": [
     "bluepy==1.3.0",
-    "git+https://github.com/TionAPI/tion_python.git@lite#tion==1.0.0"
+    "tion-btle==0.1.1"
   ],
   "codeowners": [
     "@IATkachenko"


### PR DESCRIPTION
Python module was uploaded to PyPi, so we may use it instead of github
version.
We have to rename module,
  because "tion" used by project for controling via MagicAir.