### PR TITLE
fix: round up filter remain days

### DIFF
--- a/custom_components/tion/__init__.py
+++ b/custom_components/tion/__init__.py
@@ -2,6 +2,7 @@
 import logging
 import datetime
 from typing import Union
+import math
 
 from bluepy import btle
 from tion_btle.tion import tion
@@ -107,7 +108,7 @@ class TionInstance:
                 self.__fan_speed = response["fan_speed"]
                 self.__is_heating = decode_state(response["heating"])
                 self.__in_temp = response["in_temp"]
-                self.__filter_remain = response["filter_remain"]
+                self.__filter_remain = math.ceil(response["filter_remain"])
                 self._next_update = 0
                 if type(self.__tion) is S3:
                     # Only S3 report firmware version


### PR DESCRIPTION
Tion Lite calculates filter remains from seconds, so we should round it up.

fixes #40