### PR TITLE
Add version to custom component manifest

### DIFF
--- a/custom_components/tion/manifest.json
+++ b/custom_components/tion/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "tion",
   "name": "Tion breezer",
+  "version": "1.7.1",
   "documentation": "https://github.com/TionAPI/HA-tion/wiki",
   "dependencies": [
     "fan"


### PR DESCRIPTION
Starting from 2021.06, Home Assistant requires version in custom components' manifests, disabling them if missing.