### PR TITLE
fix: use btle_exec_helper wrapper for __tion.get

### DIFF
--- a/custom_components/tion/__init__.py
+++ b/custom_components/tion/__init__.py
@@ -103,7 +103,7 @@ class TionInstance:
         response = {}
         if self._next_update <= now or force:
             try:
-                response = self.__tion.get(keep_connection)
+                response = await btle_exec_helper(self.__tion.get, keep_connection)
                 self._next_update = 0
                 if self.__tion.model == "S3":
                     # Only S3 report firmware version


### PR DESCRIPTION
It was missed while https://github.com/TionAPI/HA-tion/commit/b3acfae1f3ba645ab15dde2a04329ba0078b9689 after #63 
Restore original idea of #63.