### PR TITLE
Add fan support

### DIFF
--- a/custom_components/tion/__init__.py
+++ b/custom_components/tion/__init__.py
@@ -133,7 +133,8 @@ class TionInstance(DataUpdateCoordinator):
         _LOGGER.info("Need to set: " + args)
         await btle_exec_helper(self.__tion.set, kwargs)
         self.data.update(original_args)
-        self.async_set_updated_data()
+        for update_callback in self._listeners:
+            update_callback()
 
     @staticmethod
     def getTion(model: str, mac: str) -> tion:

--- a/custom_components/tion/__init__.py
+++ b/custom_components/tion/__init__.py
@@ -133,6 +133,7 @@ class TionInstance(DataUpdateCoordinator):
         _LOGGER.info("Need to set: " + args)
         await btle_exec_helper(self.__tion.set, kwargs)
         self.data.update(original_args)
+        self.async_set_updated_data()
 
     @staticmethod
     def getTion(model: str, mac: str) -> tion:

--- a/custom_components/tion/climate.py
+++ b/custom_components/tion/climate.py
@@ -280,3 +280,7 @@ class TionClimateEntity(ClimateEntity, CoordinatorEntity):
     @property
     def fan_modes(self) -> list[str] | None:
         return [str(i) for i in self._attr_fan_modes]
+
+    @classmethod
+    def attr_fan_modes(cls) -> list[int] | None:
+        return cls._attr_fan_modes

--- a/custom_components/tion/const.py
+++ b/custom_components/tion/const.py
@@ -26,7 +26,7 @@ CONF_KEEP_ALIVE = "keep_alive"
 CONF_INITIAL_HVAC_MODE = "initial_hvac_mode"
 CONF_AWAY_TEMP = "away_temp"
 CONF_MAC = "mac"
-PLATFORMS = [Platform.SENSOR, Platform.CLIMATE, Platform.SELECT]
+PLATFORMS = [Platform.SENSOR, Platform.CLIMATE, Platform.SELECT, Platform.FAN]
 SUPPORTED_DEVICES = ['S3', 'S4', 'Lite']
 SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE | SUPPORT_FAN_MODE
 

--- a/custom_components/tion/fan.py
+++ b/custom_components/tion/fan.py
@@ -121,10 +121,11 @@ class TionFan(FanEntity, CoordinatorEntity):
 
     async def async_turn_on(self, percentage: int | None = None, preset_mode: str | None = None, **kwargs, ) -> None:
         target_speed = 2 if self._saved_fan_mode is None else self._saved_fan_mode
-        await self.coordinator.set(fan_speed=target_speed)
+        self._saved_fan_mode = None
+        await self.coordinator.set(fan_speed=target_speed, is_on=True)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
-        if self._saved_fan_mode is None:
+        if self._saved_fan_mode is None and self.fan_mode > 0:
             self._saved_fan_mode = self.fan_mode
 
         await self.coordinator.set(is_on=False)

--- a/custom_components/tion/fan.py
+++ b/custom_components/tion/fan.py
@@ -132,5 +132,5 @@ class TionFan(FanEntity, CoordinatorEntity):
     def _handle_coordinator_update(self) -> None:
         self._attr_assumed_state = False if self.coordinator.last_update_success else True
         self._attr_is_on = self.coordinator.data.get("is_on")
-        self._attr_percentage = self.mode2percent()
+        self._attr_percentage = self.mode2percent() if self.is_on else 0
         self.async_write_ha_state()

--- a/custom_components/tion/fan.py
+++ b/custom_components/tion/fan.py
@@ -75,7 +75,7 @@ class TionFan(FanEntity, CoordinatorEntity):
         self._attr_name = f"{instance.name} {description.name}"
         self._attr_device_info = instance.device_info
         self._attr_unique_id = f"{instance.unique_id}-{description.key}"
-        self._saved_fan_mode = 0
+        self._saved_fan_mode = None
 
         _LOGGER.debug(f"Init of fan  {self.name} ({instance.unique_id})")
 

--- a/custom_components/tion/fan.py
+++ b/custom_components/tion/fan.py
@@ -1,0 +1,134 @@
+"""
+Fan controls for Tion breezers
+"""
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+from functools import cached_property
+from typing import Any
+
+from homeassistant.components.climate.const import PRESET_BOOST, PRESET_NONE
+from homeassistant.components.fan import FanEntityDescription, FanEntity, SUPPORT_SET_SPEED, SUPPORT_PRESET_MODE, \
+    DIRECTION_FORWARD
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from . import TionInstance
+from .climate import TionClimateEntity
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+SCAN_INTERVAL = timedelta(seconds=30)
+
+config = FanEntityDescription(
+    key="fan_speed",
+    entity_category=EntityCategory.CONFIG,
+    name="fan speed",
+    entity_registry_enabled_default=True,
+    icon="mdi:fan",
+)
+
+
+async def async_setup_entry(hass: HomeAssistant, _config: ConfigEntry, async_add_entities):
+    """Set up the sensor entry"""
+
+    async_add_entities([TionFan(config, hass.data[DOMAIN][_config.unique_id])])
+    return True
+
+
+class TionFan(FanEntity, CoordinatorEntity):
+    _attr_supported_features = SUPPORT_PRESET_MODE | SUPPORT_SET_SPEED
+    _attr_oscillating = False
+    _attr_preset_modes = [PRESET_NONE, PRESET_BOOST]
+    _attr_speed_count = len(TionClimateEntity.attr_fan_modes())
+    _attr_current_direction = DIRECTION_FORWARD
+
+    """Representation of a fan control."""
+
+    def set_preset_mode(self, preset_mode: str) -> None:
+        pass
+
+    def set_direction(self, direction: str) -> None:
+        raise NotImplemented
+
+    def turn_on(self, percentage: int | None = None, preset_mode: str | None = None, **kwargs) -> None:
+        raise NotImplemented
+
+    def oscillate(self, oscillating: bool) -> None:
+        raise NotImplemented
+
+    def turn_off(self, **kwargs: Any) -> None:
+        pass
+
+    def set_percentage(self, percentage: int) -> None:
+        raise NotImplemented
+
+    def __init__(self, description: FanEntityDescription, instance: TionInstance):
+        """Initialize the fan."""
+
+        CoordinatorEntity.__init__(self=self, coordinator=instance, )
+        self.entity_description = description
+        self._attr_name = f"{instance.name} {description.name}"
+        self._attr_device_info = instance.device_info
+        self._attr_unique_id = f"{instance.unique_id}-{description.key}"
+        self._saved_fan_mode = 0
+
+        _LOGGER.debug(f"Init of fan  {self.name} ({instance.unique_id})")
+
+    def percent2mode(self, percentage: int) -> int:
+        fan_modes_count = len(TionClimateEntity.attr_fan_modes())
+        return 0 if percentage == 0 else \
+            1 if percentage < 100 / self.percentage_step else \
+            2 if percentage < 100 / self.percentage_step * 2 else \
+            3 if percentage < 100 / self.percentage_step * 3 else \
+            4 if percentage < 100 / self.percentage_step * 4 else \
+            5 if percentage < 100 / self.percentage_step * 5 else \
+            6
+
+    def mode2percent(self) -> int | None:
+        return int(self.percentage_step * self.fan_mode) if self.fan_mode is not None else None
+
+    async def async_set_percentage(self, percentage: int) -> None:
+        """Set the speed of the fan, as a percentage."""
+        await self.coordinator.set(fan_speed=self.percent2mode(percentage))
+
+    @cached_property
+    def boost_fan_mode(self) -> int:
+        return max(TionClimateEntity.attr_fan_modes())
+
+    @property
+    def fan_mode(self):
+        return self.coordinator.data.get(self.entity_description.key)
+
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        if preset_mode == PRESET_BOOST and self.preset_mode != PRESET_BOOST:
+            if self._saved_fan_mode is None:
+                self._saved_fan_mode = int(self.fan_mode)
+
+            await self.coordinator.set(fan_speed=self.boost_fan_mode)
+        if preset_mode == PRESET_NONE and self.preset_mode == PRESET_BOOST:
+            if self._saved_fan_mode is not None:
+                await self.coordinator.set(fan_speed=self._saved_fan_mode)
+                self._saved_fan_mode = None
+
+        self._attr_preset_mode = preset_mode
+
+    async def async_turn_on(self, percentage: int | None = None, preset_mode: str | None = None, **kwargs, ) -> None:
+        target_speed = 2 if self._saved_fan_mode is None else self._saved_fan_mode
+        await self.coordinator.set(fan_speed=target_speed)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        if self._saved_fan_mode is None:
+            self._saved_fan_mode = self.fan_mode
+
+        await self.coordinator.set(is_on=False)
+
+    def _handle_coordinator_update(self) -> None:
+        self._attr_assumed_state = False if self.coordinator.last_update_success else True
+        self._attr_is_on = self.coordinator.data.get("is_on")
+        self._attr_percentage = self.mode2percent()
+        self.async_write_ha_state()

--- a/custom_components/tion/fan.py
+++ b/custom_components/tion/fan.py
@@ -96,7 +96,7 @@ class TionFan(FanEntity, CoordinatorEntity):
 
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the speed of the fan, as a percentage."""
-        await self.coordinator.set(fan_speed=self.percent2mode(percentage))
+        await self.coordinator.set(fan_speed=self.percent2mode(percentage), is_on=percentage > 0)
 
     @cached_property
     def boost_fan_mode(self) -> int:

--- a/custom_components/tion/fan.py
+++ b/custom_components/tion/fan.py
@@ -132,5 +132,5 @@ class TionFan(FanEntity, CoordinatorEntity):
     def _handle_coordinator_update(self) -> None:
         self._attr_assumed_state = False if self.coordinator.last_update_success else True
         self._attr_is_on = self.coordinator.data.get("is_on")
-        self._attr_percentage = self.mode2percent() if self.is_on else 0
+        self._attr_percentage = self.mode2percent() if self._attr_is_on else 0  # should check attr to avoid deadlock
         self.async_write_ha_state()

--- a/custom_components/tion/fan.py
+++ b/custom_components/tion/fan.py
@@ -80,14 +80,16 @@ class TionFan(FanEntity, CoordinatorEntity):
         _LOGGER.debug(f"Init of fan  {self.name} ({instance.unique_id})")
 
     def percent2mode(self, percentage: int) -> int:
-        fan_modes_count = len(TionClimateEntity.attr_fan_modes())
-        return 0 if percentage == 0 else \
-            1 if percentage < 100 / self.percentage_step else \
-            2 if percentage < 100 / self.percentage_step * 2 else \
-            3 if percentage < 100 / self.percentage_step * 3 else \
-            4 if percentage < 100 / self.percentage_step * 4 else \
-            5 if percentage < 100 / self.percentage_step * 5 else \
-            6
+        result = 0
+        for i in range(len(TionClimateEntity.attr_fan_modes())):
+            if percentage < self.percentage_step * i:
+                break
+            else:
+                result = i
+        else:
+            result = 6
+
+        return result
 
     def mode2percent(self) -> int | None:
         return int(self.percentage_step * self.fan_mode) if self.fan_mode is not None else None


### PR DESCRIPTION
В устройство добавляется отдельный компонент `fan`, что позволит управлять скоростью вентиляторая из специализированных карточках HA, не затрагивая `climate`.

Реализует запрос #80 