### PR TITLE
i77

### DIFF
--- a/custom_components/tion/__init__.py
+++ b/custom_components/tion/__init__.py
@@ -164,7 +164,7 @@ class TionInstance(DataUpdateCoordinator):
 
     @cached_property
     def unique_id(self):
-        return self.__tion.mac
+        return self.config[CONF_MAC]
 
     @cached_property
     def supported_air_sources(self) -> list[str]:

--- a/custom_components/tion/__init__.py
+++ b/custom_components/tion/__init__.py
@@ -73,15 +73,17 @@ class TionInstance(DataUpdateCoordinator):
 
     @property
     def config(self) -> dict:
-        config = {}
-        if hasattr(self._config_entry, 'options'):
-            if any(self._config_entry.options):
-                config = self._config_entry.options
-        if not any(config):
-            if hasattr(self._config_entry, 'data'):
-                if any(self._config_entry.data):
-                    config = self._config_entry.data
-        return config
+        try:
+            data = dict(self._config_entry.data or {})
+        except AttributeError:
+            data = {}
+
+        try:
+            options = self._config_entry.options or {}
+            data.update(options)
+        except AttributeError:
+            pass
+        return data
 
     @staticmethod
     def _decode_state(state: str) -> bool:
@@ -166,7 +168,7 @@ class TionInstance(DataUpdateCoordinator):
 
     @cached_property
     def supported_air_sources(self) -> list[str]:
-        if self.config["model"] == "S3":
+        if self.model == "S3":
             return ["outside", "mixed", "recirculation"]
         else:
             return ["outside", "recirculation"]

--- a/custom_components/tion/__init__.py
+++ b/custom_components/tion/__init__.py
@@ -52,9 +52,7 @@ class TionInstance(DataUpdateCoordinator):
         # delay before next update if we got btle.BTLEDisconnectError
         self._delay: int = 600
 
-        model = self.model
-
-        self.__tion: tion = self.getTion(model, self.config[CONF_MAC])
+        self.__tion: tion = self.getTion(self.model, self.config[CONF_MAC])
         self.__keep_alive = datetime.timedelta(seconds=self.__keep_alive)
         self._delay = datetime.timedelta(seconds=self._delay)
 

--- a/custom_components/tion/__init__.py
+++ b/custom_components/tion/__init__.py
@@ -56,6 +56,15 @@ class TionInstance(DataUpdateCoordinator):
         self.__keep_alive = datetime.timedelta(seconds=self.__keep_alive)
         self._delay = datetime.timedelta(seconds=self._delay)
 
+        if self._config_entry.unique_id is None:
+            _LOGGER.critical(f"Unique id is None for {self.config_entry.title}! "
+                             f"Will fix it by using {self.unique_id}")
+            hass.config_entries.async_update_entry(
+                entry=self._config_entry,
+                unique_id=self.unique_id,
+            )
+            _LOGGER.critical("Done! Please restart Home Assistant.")
+
         super().__init__(
             name=self.config['name'] if 'name' in self.config else TION_SCHEMA['name']['default'],
             hass=hass,

--- a/custom_components/tion/__init__.py
+++ b/custom_components/tion/__init__.py
@@ -52,12 +52,7 @@ class TionInstance(DataUpdateCoordinator):
         # delay before next update if we got btle.BTLEDisconnectError
         self._delay: int = 600
 
-        try:
-            model = self.config['model']
-        except KeyError:
-            _LOGGER.warning("Model was not found in config. Please update integration settings!")
-            _LOGGER.warning("Assume that model is S3")
-            model = 'S3'
+        model = self.model
 
         self.__tion: tion = self.getTion(model, self.config[CONF_MAC])
         self.__keep_alive = datetime.timedelta(seconds=self.__keep_alive)
@@ -173,3 +168,13 @@ class TionInstance(DataUpdateCoordinator):
         else:
             return ["outside", "recirculation"]
 
+    @cached_property
+    def model(self) -> str:
+        try:
+            model = self.config['model']
+        except KeyError:
+            _LOGGER.warning(f"Model was not found in config. "
+                            f"Please update integration settings! Config is {self.config}")
+            _LOGGER.warning("Assume that model is S3")
+            model = 'S3'
+        return model

--- a/custom_components/tion/config_flow.py
+++ b/custom_components/tion/config_flow.py
@@ -71,16 +71,17 @@ class TionFlow:
 
     @property
     def config(self) -> dict:
-        config = {}
-        if hasattr(self._config_entry, 'options'):
-            if any(self._config_entry.options):
-                config = self._config_entry.options
-        if not any(config):
-            if hasattr(self._config_entry, 'data'):
-                if any(self._config_entry.data):
-                    config = self._config_entry.data
+        try:
+            data = dict(self._config_entry.data or {})
+        except AttributeError:
+            data = {}
 
-        return config
+        try:
+            options = self._config_entry.options or {}
+            data.update(options)
+        except AttributeError:
+            pass
+        return data
 
     @staticmethod
     def getTion(model: str, mac: str) -> tion:

--- a/custom_components/tion/config_flow.py
+++ b/custom_components/tion/config_flow.py
@@ -109,6 +109,9 @@ class TionConfigFlow(TionFlow, config_entries.ConfigFlow, domain=DOMAIN):
     def async_get_options_flow(config_entry):
         return TionOptionsFlowHandler(config_entry)
 
+    def _create_entry(self, data, title):
+        return self.async_create_entry(title=title, data=data)
+
     async def async_step_user(self, input=None):
         """user initiates a flow via the user interface."""
 
@@ -128,7 +131,7 @@ class TionConfigFlow(TionFlow, config_entries.ConfigFlow, domain=DOMAIN):
                     _LOGGER.error("Could not get data from breezer. result is %s, error: %s" % (result, str(e)))
                     return self.async_show_form(step_id='add_failed')
 
-                return self.async_create_entry(title=input['name'], data=input)
+                return self._create_entry(title=input['name'], data=input)
 
         return self.async_show_form(step_id="user", data_schema=self.get_schema(TION_SCHEMA))
 
@@ -150,7 +153,7 @@ class TionConfigFlow(TionFlow, config_entries.ConfigFlow, domain=DOMAIN):
                           type(e).__name__, str(e))
             return self.async_show_form(step_id='pair_failed')
 
-        return self.async_create_entry(title=self._data['name'], data=self._data)
+        return self._create_entry(title=self._data['name'], data=self._data)
 
     async def async_step_add_failed(self, input):
         _LOGGER.debug("Add failed. Returning to first step")

--- a/custom_components/tion/config_flow.py
+++ b/custom_components/tion/config_flow.py
@@ -1,21 +1,16 @@
 """Adds config flow for Tion custom component."""
-import asyncio
-import os
 import logging
 import datetime
 import time
 
 import voluptuous as vol
 
-from homeassistant import data_entry_flow
-
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.util.json import load_json
 from homeassistant.core import callback
 from tion_btle.tion import tion
 
-from .const import DOMAIN, TION_SCHEMA, CONF_KEEP_ALIVE
+from .const import DOMAIN, TION_SCHEMA
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/tion/config_flow.py
+++ b/custom_components/tion/config_flow.py
@@ -153,6 +153,7 @@ class TionFlow:
 
 @config_entries.HANDLERS.register(DOMAIN)
 class TionConfigFlow(TionFlow, config_entries.ConfigFlow, domain=DOMAIN):
+    """Initial setup."""
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 
@@ -166,6 +167,7 @@ class TionConfigFlow(TionFlow, config_entries.ConfigFlow, domain=DOMAIN):
 
 
 class TionOptionsFlowHandler(TionFlow, config_entries.OptionsFlow):
+    """Change options dialog."""
 
     def __init__(self, config_entry):
         """Initialize Shelly options flow."""

--- a/custom_components/tion/config_flow.py
+++ b/custom_components/tion/config_flow.py
@@ -96,7 +96,6 @@ class TionFlow:
         return Tion(mac)
 
 
-@config_entries.HANDLERS.register(DOMAIN)
 class TionConfigFlow(TionFlow, config_entries.ConfigFlow, domain=DOMAIN):
     """Initial setup."""
     VERSION = 1

--- a/custom_components/tion/translations/en.json
+++ b/custom_components/tion/translations/en.json
@@ -29,27 +29,16 @@
   },
   "options": {
     "step": {
-      "user": {
+      "init": {
         "title": "Configuration for Tion breezer",
         "data": {
+          "model": "Device model",
           "mac": "Device MAC address",
           "name": "Name for device",
           "away_temp": "Temperature (celsius) for AWAY mode",
           "keep_alive": "Interval for querying breezer",
           "pair": "Need device pairing?"
         }
-      },
-      "pair": {
-        "title": "Device pairing",
-        "description": "Turn breezer to pair mode by holding button for more than 5 seconds for pairing with Home Assistant.\n\nMake sure that there is no devices connected to breezer while adding it to Home Assistant.\n\n![Location of button on bridge](/static/images/config_philips_hue.jpg)"
-      },
-      "pair_failed": {
-        "title": "Could not pair!",
-        "description": "Error occurs while pairing routine! Check logs for details.\n\nMake sure that there is no devices connected to breezer while adding it to Home Assistant."
-      },
-      "add_failed": {
-        "title": "Could not get test data from breezer!",
-        "description": "Error occurs while getting data. May be you need pairing. Check logs for details.\n\nMake sure that there is no devices connected to breezer while adding it to Home Assistant."
       }
     }
   }


### PR DESCRIPTION
Some refactoring and fix #77.

We should split `init` (settings update) and `user` (initial configuration) steps.
While user we should assign mac-based unique_id to config entry.

If config entry have no `unique_id` (after 2.2.0), then we should add it and ask user for restart.
