### PR TITLE
chore(updater)!: use async_update_listeners

### DIFF
--- a/custom_components/tion/__init__.py
+++ b/custom_components/tion/__init__.py
@@ -131,8 +131,7 @@ class TionInstance(DataUpdateCoordinator):
         _LOGGER.info("Need to set: " + args)
         await self.__tion.set(kwargs)
         self.data.update(original_args)
-        for update_callback in self._listeners:
-            update_callback()
+        self.async_update_listeners()
 
     @staticmethod
     def getTion(model: str, mac: str) -> tion_btle.TionS3 | tion_btle.TionLite | tion_btle.TionS4:

--- a/hacs.json
+++ b/hacs.json
@@ -4,5 +4,5 @@
   "render_readme": true,
   "zip_release": true,
   "filename": "tion.zip",
-  "homeassistant":  "2022.6.0"
+  "homeassistant":  "2022.7.0"
 }


### PR DESCRIPTION
If we have updated data, then we may just call for update listeners.

BREAKING CHANGE: async_update_listeners was added in 2022.7, so minimum version bumped.

May wait for next major update.