### PR TITLE
fix: avoid traces while startup

### DIFF
--- a/custom_components/ha_tion_btle/manifest.json
+++ b/custom_components/ha_tion_btle/manifest.json
@@ -7,7 +7,7 @@
     "fan"
   ],
   "requirements": [
-    "tion-btle==3.3.4"
+    "tion-btle==3.3.5"
   ],
   "codeowners": [
     "@IATkachenko"

--- a/custom_components/ha_tion_btle/manifest.json.tpl
+++ b/custom_components/ha_tion_btle/manifest.json.tpl
@@ -7,7 +7,7 @@
     "fan"
   ],
   "requirements": [
-    "tion-btle==3.3.4"
+    "tion-btle==3.3.5"
   ],
   "codeowners": [
     "@IATkachenko"


### PR DESCRIPTION
If we have no correct `_btle` object while startup, then integration fails while processing log message while `_btle` update.
Actual fix is in `tion_btle` [v3.3.5](https://github.com/TionAPI/tion_python/releases/tag/v3.3.5), so bumping module version.