### PR TITLE
fix: migrate to `async_forward_entry_setup`

### DIFF
--- a/custom_components/ha_tion_btle/__init__.py
+++ b/custom_components/ha_tion_btle/__init__.py
@@ -42,8 +42,11 @@ async def async_setup_entry(hass, config_entry: ConfigEntry):
     )
 
     await hass.data[DOMAIN][config_entry.unique_id].async_config_entry_first_refresh()
-    hass.config_entries.async_setup_platforms(config_entry, PLATFORMS)
-    return True
+
+    result = True
+    for platform in PLATFORMS:
+        result = result & await hass.config_entries.async_forward_entry_setup(entry=config_entry, domain=platform)
+    return result
 
 
 class TionInstance(DataUpdateCoordinator):


### PR DESCRIPTION
Platforms initialisation via `async_setup_platforms` is deprecated

Fix #122 